### PR TITLE
Update composer-plugin-api to 2.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=7.4",
-        "composer-plugin-api": "^1.1.0"
+        "composer-plugin-api": "^2.0.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "32a1e2985688bbe4f48633e0dda9176a",
+    "content-hash": "7ea67f8f8cfa748b711ef49757f57c3a",
     "packages": [],
     "packages-dev": [
         {
@@ -4710,8 +4710,8 @@
     "prefer-lowest": false,
     "platform": {
         "php": ">=7.4",
-        "composer-plugin-api": "^1.1.0"
+        "composer-plugin-api": "^2.0.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.0.0"
 }


### PR DESCRIPTION
As you can see, composer 2 is out: https://blog.packagist.com/composer-2-0-is-now-available/

And, because we are using the latest composer version (from today on is version 2), we should update this as well, in order to get rid of this error from `phel-lang` project

```
Problem 1
  - phel/phel-composer-plugin dev-master requires composer-plugin-api ^1.1.0 -> found composer-plugin-api[2.0.0] but it does not match the constraint.
```